### PR TITLE
Переход на .NET Standard 2.1 и изменение поведения

### DIFF
--- a/Tests/YY.EventLogReaderAssistant.Tests/YY.EventLogReaderAssistant.Tests.csproj
+++ b/Tests/YY.EventLogReaderAssistant.Tests/YY.EventLogReaderAssistant.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.113.1" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.113.5" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/YY.EventLogReaderAssistant/EventLogLGDReader.cs
+++ b/YY.EventLogReaderAssistant/EventLogLGDReader.cs
@@ -239,13 +239,6 @@ namespace YY.EventLogReaderAssistant
 
             RowData row = new RowData();
             row.FillBySqliteReader(this, _reader);
-
-            if (!EventAllowedByPeriod(row))
-            {
-                _currentRow = null;
-                return false;
-            }
-
             _readBuffer.Add(row);
 
             return true;

--- a/YY.EventLogReaderAssistant/EventLogLGFReader.cs
+++ b/YY.EventLogReaderAssistant/EventLogLGFReader.cs
@@ -24,7 +24,7 @@ namespace YY.EventLogReaderAssistant
         readonly StringBuilder _eventSource;
 
         private LogParserLGF _logParser;
-        private LogParserLGF LogParser => _logParser ?? (_logParser = new LogParserLGF(this));
+        private LogParserLGF LogParser => _logParser ??= new LogParserLGF(this);
 
         #endregion
 
@@ -58,7 +58,7 @@ namespace YY.EventLogReaderAssistant
 
         public override bool Read()
         {
-            bool output = false;
+            bool output;
 
             try
             {
@@ -96,15 +96,8 @@ namespace YY.EventLogReaderAssistant
                         try
                         {
                             RowData eventData = ReadRowData(preparedSourceData);
-
-                            if (!EventAllowedByPeriod(eventData))
-                            {
-                                _currentRow = null;
-                                break;
-                            }
-
+                            
                             _currentRow = eventData;
-
                             RaiseAfterRead(new AfterReadEventArgs(_currentRow, _currentFileEventNumber));
                             output = true;
                             break;

--- a/YY.EventLogReaderAssistant/EventLogReader.cs
+++ b/YY.EventLogReaderAssistant/EventLogReader.cs
@@ -59,8 +59,6 @@ namespace YY.EventLogReaderAssistant
         protected ReferencesData _referencesData;
         protected RowData _currentRow;
 
-        protected double _readDelayMilliseconds;
-
         #endregion
 
         #region Constructor
@@ -74,8 +72,6 @@ namespace YY.EventLogReaderAssistant
 
             _referencesReadDate = DateTime.MinValue;
             ReadEventLogReferences();
-
-            _readDelayMilliseconds = 1000;
         }
 
         #endregion
@@ -90,13 +86,6 @@ namespace YY.EventLogReaderAssistant
         public string LogFilePath => _logFilePath;
         public string LogFileDirectoryPath => _logFileDirectoryPath;
         public virtual string CurrentFile => null;
-        public double ReadDelayMilliseconds
-        {
-            get
-            {
-                return _readDelayMilliseconds;
-            }
-        }
 
         #endregion
 
@@ -130,10 +119,6 @@ namespace YY.EventLogReaderAssistant
         {
             throw new NotImplementedException();
         }
-        public virtual void SetReadDelay(double milliseconds)
-        {
-            _readDelayMilliseconds = milliseconds;
-        }
         public virtual void Dispose()
         {
             _referencesData = null;
@@ -146,17 +131,6 @@ namespace YY.EventLogReaderAssistant
 
         protected virtual void ReadEventLogReferences()
         {
-        }
-        protected bool EventAllowedByPeriod(RowData eventData)
-        {
-            if (Math.Abs(_readDelayMilliseconds) > 0 && eventData != null)
-            {
-                DateTimeOffset stopPeriod = DateTimeOffset.Now.AddMilliseconds(-_readDelayMilliseconds);
-                if (eventData.Period >= stopPeriod)
-                    return false;
-            }
-
-            return true;
         }
 
         #endregion

--- a/YY.EventLogReaderAssistant/IEventLogReader.cs
+++ b/YY.EventLogReaderAssistant/IEventLogReader.cs
@@ -12,6 +12,5 @@ namespace YY.EventLogReaderAssistant
         long Count();
         void Reset();
         void NextFile();
-        void SetReadDelay(double milliseconds);
     }
 }

--- a/YY.EventLogReaderAssistant/Models/RowData.cs
+++ b/YY.EventLogReaderAssistant/Models/RowData.cs
@@ -18,7 +18,7 @@ namespace YY.EventLogReaderAssistant.Models
 
         #region Public Members
 
-        public DateTimeOffset Period { get; set; }
+        public DateTime Period { get; set; }
         public long RowId { get; set; }
         public Severity Severity { get; set; }
         public long? ConnectId { get; set; }

--- a/YY.EventLogReaderAssistant/YY.EventLogReaderAssistant.csproj
+++ b/YY.EventLogReaderAssistant/YY.EventLogReaderAssistant.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.0.36</Version>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Version>1.0.0.37</Version>
     <Description>Library for reading 1C:Enterprise 8.x platform's event log files</Description>
     <Copyright>Copyright (c) 2020 Permitin Yury</Copyright>
     <PackageProjectUrl>https://github.com/YPermitin/YY.EventLogReaderAssistant</PackageProjectUrl>
@@ -15,12 +15,12 @@
     <Authors>Permitin Yuriy</Authors>
     <Product>Event log's reader assistant</Product>
     <PackageTags>event, log, 1C, enterprise</PackageTags>
-    <FileVersion>1.0.0.36</FileVersion>
-    <AssemblyVersion>1.0.0.36</AssemblyVersion>
+    <FileVersion>1.0.0.37</FileVersion>
+    <AssemblyVersion>1.0.0.37</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SQLite" Version="1.0.113.1" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.113.5" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
   </ItemGroup>
 

--- a/YY.EventLogReaderAssistantConsoleApp/Program.cs
+++ b/YY.EventLogReaderAssistantConsoleApp/Program.cs
@@ -7,6 +7,7 @@ namespace YY.EventLogReaderAssistantConsoleApp
     static class Program
     {
         private static int _eventNumber;
+        private static DateTime _lastPeriodEvent = DateTime.MinValue;
 
         static void Main(string[] args)
         {
@@ -43,6 +44,7 @@ namespace YY.EventLogReaderAssistantConsoleApp
         {
             Console.WriteLine($"{DateTime.Now}: Начало чтения файла \"{args.FileName}\"");
             Console.WriteLine($"{DateTime.Now}: {_eventNumber}");
+            Console.WriteLine($"{DateTime.Now}: {_lastPeriodEvent}");
         }
 
         private static void Reader_AfterReadFile(EventLogReader sender, AfterReadFileEventArgs args)
@@ -52,14 +54,19 @@ namespace YY.EventLogReaderAssistantConsoleApp
 
         private static void Reader_BeforeReadEvent(EventLogReader sender, BeforeReadEventArgs args)
         {
-            Console.SetCursorPosition(0, Console.CursorTop - 1);
+            Console.SetCursorPosition(0, Console.CursorTop - 2);
             Console.WriteLine($"{DateTime.Now}: (+){_eventNumber}");
+            Console.WriteLine($"{DateTime.Now}: {_lastPeriodEvent}");
         }
 
         private static void Reader_AfterReadEvent(EventLogReader sender, AfterReadEventArgs args)
         {
-            Console.SetCursorPosition(0, Console.CursorTop - 1);
+            if(args.RowData != null)
+                _lastPeriodEvent = args.RowData.Period;
+
+            Console.SetCursorPosition(0, Console.CursorTop - 2);
             Console.WriteLine($"{DateTime.Now}: [+]{_eventNumber}");
+            Console.WriteLine($"{DateTime.Now}: {_lastPeriodEvent}");
         }
 
         private static void Reader_OnErrorEvent(EventLogReader sender, OnErrorEventArgs args)


### PR DESCRIPTION
- Библиотека переведена на .NET Standard 2.1
- Отказ от настроек и методов задержки чтения
- Отказ от DateTimeOffset в пользу DateTime из-за отсутствия необходимости его использовать
- Обновлена библиотека для работы со SQLite (используется для LGD-формата)
- Обновлена версия библиотеки
- В примере приложения добавлен вывод дополнительных значений
- Другие небольшие улучшения