### PR TITLE
Добавлена настройка часового пояса

### DIFF
--- a/YY.EventLogReaderAssistant/EventLogLGDReader.cs
+++ b/YY.EventLogReaderAssistant/EventLogLGDReader.cs
@@ -300,7 +300,7 @@ namespace YY.EventLogReaderAssistant
         }
         protected override void ReadEventLogReferences()
         {
-            DateTime beginReadReferences = DateTime.Now;
+            DateTime beginReadReferences = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, _logTimeZoneInfo);
 
             using (_connection = new SQLiteConnection(ConnectionString))
             {

--- a/YY.EventLogReaderAssistant/EventLogLGFReader.cs
+++ b/YY.EventLogReaderAssistant/EventLogLGFReader.cs
@@ -247,7 +247,7 @@ namespace YY.EventLogReaderAssistant
         }
         protected override void ReadEventLogReferences()
         {
-            DateTime beginReadReferences = DateTime.Now;
+            DateTime beginReadReferences = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, _logTimeZoneInfo);
             _referencesData = new ReferencesData();
 
             var referencesInfo = LogParser.GetEventLogReferences();

--- a/YY.EventLogReaderAssistant/EventLogReader.cs
+++ b/YY.EventLogReaderAssistant/EventLogReader.cs
@@ -54,7 +54,7 @@ namespace YY.EventLogReaderAssistant
         protected readonly string _logFilePath;
         protected readonly string _logFileDirectoryPath;
         protected long _currentFileEventNumber;
-
+        protected TimeZoneInfo _logTimeZoneInfo;
         protected DateTime _referencesReadDate;
         protected ReferencesData _referencesData;
         protected RowData _currentRow;
@@ -69,7 +69,7 @@ namespace YY.EventLogReaderAssistant
         {
             _logFilePath = logFilePath;
             _logFileDirectoryPath = new FileInfo(_logFilePath).Directory?.FullName;
-
+            _logTimeZoneInfo = TimeZoneInfo.Local;
             _referencesReadDate = DateTime.MinValue;
             ReadEventLogReferences();
         }
@@ -130,6 +130,14 @@ namespace YY.EventLogReaderAssistant
         public virtual bool LastFile()
         {
             throw new NotImplementedException();
+        }
+        public void SetTimeZone(TimeZoneInfo timeZone)
+        {
+            _logTimeZoneInfo = timeZone;
+        }
+        public TimeZoneInfo GetTimeZone()
+        {
+            return _logTimeZoneInfo;
         }
         public virtual void Dispose()
         {

--- a/YY.EventLogReaderAssistant/IEventLogReader.cs
+++ b/YY.EventLogReaderAssistant/IEventLogReader.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("YY.EventLogReaderAssistant.Tests")]
 namespace YY.EventLogReaderAssistant
@@ -15,5 +16,7 @@ namespace YY.EventLogReaderAssistant
         bool PreviousFile();
         bool NextFile();
         bool LastFile();
+        void SetTimeZone(TimeZoneInfo timeZone);
+        TimeZoneInfo GetTimeZone();
     }
 }

--- a/YY.EventLogReaderAssistant/YY.EventLogReaderAssistant.csproj
+++ b/YY.EventLogReaderAssistant/YY.EventLogReaderAssistant.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.0.0.41</Version>
+    <Version>1.0.0.42</Version>
     <Description>Library for reading 1C:Enterprise 8.x platform's event log files</Description>
     <Copyright>Copyright (c) 2020 Permitin Yury</Copyright>
     <PackageProjectUrl>https://github.com/YPermitin/YY.EventLogReaderAssistant</PackageProjectUrl>
@@ -15,9 +15,9 @@
     <Authors>Permitin Yuriy</Authors>
     <Product>Event log's reader assistant</Product>
     <PackageTags>event, log, 1C, enterprise</PackageTags>
-    <FileVersion>1.0.0.41</FileVersion>
-    <AssemblyVersion>1.0.0.41</AssemblyVersion>
-    <PackageVersion>1.0.0.41</PackageVersion>
+    <FileVersion>1.0.0.42</FileVersion>
+    <AssemblyVersion>1.0.0.42</AssemblyVersion>
+    <PackageVersion>1.0.0.42</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/YY.EventLogReaderAssistantConsoleApp/Program.cs
+++ b/YY.EventLogReaderAssistantConsoleApp/Program.cs
@@ -17,11 +17,16 @@ namespace YY.EventLogReaderAssistantConsoleApp
             if (args.Length == 0)
                 return;
 
+            TimeZoneInfo timeZoneSetting = TimeZoneInfo.Local;
+            if (args.Length >= 3)
+                timeZoneSetting = TimeZoneInfo.FindSystemTimeZoneById(args[2]);
+
             string dataDirectoryPath = args[0];
             Console.WriteLine($"{DateTime.Now}: Инициализация чтения логов \"{dataDirectoryPath}\"...");
 
             using (EventLogReader reader = EventLogReader.CreateReader(dataDirectoryPath))
             {
+                reader.SetTimeZone(timeZoneSetting);
                 InitializingEventHandlers(reader);
                 if (args.Contains("LastFile"))
                     reader.LastFile();


### PR DESCRIPTION
Настройка нужна для корректной обработки обновления ссылочных данных в зависимости от даты событий.

Актуально в тех случаях, когда сервер с файлами логов и сервер с приложением обработки логов находятся в разных часовых поясах.